### PR TITLE
Add support for all oidcc claims

### DIFF
--- a/src/main/java/com/authlete/jaxrs/server/db/UserDao.java
+++ b/src/main/java/com/authlete/jaxrs/server/db/UserDao.java
@@ -32,38 +32,152 @@ public class UserDao
      * Dummy user database.
      */
     private static final UserEntity[] sUserDB = {
-            new UserEntity("1001", "John Smith", "john@example.com",
-                    new Address().setCountry("USA"), "+1 (425) 555-1212"),
-            new UserEntity("1002", "Jane Smith", "jane@example.com",
-                    new Address().setCountry("Chile"), "+56 (2) 687 2400"),
-            new UserEntity("1003", "Max Meier", "max@example.com",
-                    new Address().setCountry("Germany"), "+49 (30) 210 94-0"),
+            new UserEntity("1001", "john", "john", "John Smith", "john@example.com",
+                    new Address().setCountry("USA"), "+1 (425) 555-1212", "675325"),
+            new UserEntity("1002", "jane", "jane", "Jane Smith", "jane@example.com",
+                    new Address().setCountry("Chile"), "+56 (2) 687 2400", "264209"),
+            new UserEntity("1003", "max", "max", "Max Meier", "max@example.com",
+                    new Address().setCountry("Germany"), "+49 (30) 210 94-0", "12344"),
     };
 
 
     /**
-     * Get a user entity by a subject.
+     * Condition for user search.
+     */
+    private static interface SearchCondition
+    {
+        boolean check(UserEntity ue);
+    }
+
+
+    /**
+     * Get a user who meets the condition.
      *
-     * @param subject
-     *         A subject (= unique identifier) of a user.
+     * @param condition
+     *         The condition for searching a user.
      *
      * @return
-     *         A user entity that has the subject. {@code null} is
-     *         returned if there is no user who has the subject.
+     *         A user who meets the condition.
      */
-    public static User getBySubject(String subject)
+    private static User get(SearchCondition condition)
     {
         // For each user.
         for (UserEntity ue : sUserDB)
         {
-            if (ue.getSubject().equals(subject))
+            // If the condition is satisfied.
+            if (condition.check(ue))
             {
-                // Found the user whose subject matches the specified one.
+                // Found the user who meets the condition.
                 return ue;
             }
         }
 
-        // Not found any user whose subject matches the specified one.
+        // Not found any user who meets the condition.
         return null;
+    }
+
+
+    /**
+     * Get a user entity by a pair of login ID and password.
+     *
+     * @param loginId
+     *         Login ID.
+     *
+     * @param password
+     *         Login password.
+     *
+     * @return
+     *         A user entity that has the login ID and the password.
+     *         {@code null} is returned if there is no user who has
+     *         the login credentials.
+     */
+    public static User getByCredentials(final String loginId, final String password)
+    {
+        return get(new SearchCondition() {
+            @Override
+            public boolean check(UserEntity ue)
+            {
+                // Check if the user's credentials are the target ones.
+                return ue.getLoginId().equals(loginId) && ue.getPassword().equals(password);
+            }
+        });
+    }
+
+
+    /**
+     * Get a user by a subject.
+     *
+     * @param subject
+     *         The subject of a user.
+     *
+     * @return
+     *         A user entity that has the subject.
+     *         {@code null} is returned if there is no user who has
+     *         the subject.
+     */
+    public static User getBySubject(final String subject)
+    {
+        return get(new SearchCondition() {
+            @Override
+            public boolean check(UserEntity ue)
+            {
+                // Check if the user's subject is the target one.
+                return ue.getSubject().equals(subject);
+            }
+        });
+    }
+
+
+    /**
+     * Get a user by an email address.
+     *
+     * @param email
+     *         An email address.
+     *
+     * @return
+     *         A user entity that has the email address.
+     *         {@code null} is returned if there is no user who has
+     *         the email address.
+     */
+    public static User getByEmail(final String email)
+    {
+        return get(new SearchCondition() {
+            @Override
+            public boolean check(UserEntity ue)
+            {
+                // Get the user's "email" claim.
+                String e = (String)ue.getClaim("email", null);
+
+                // Check if the user's email is the target one.
+                return e != null && e.equals(email);
+            }
+        });
+    }
+
+
+    /**
+     * Get a user by a phone number.
+     *
+     * @param phoneNumber
+     *         A phone number.
+     *
+     * @return
+     *         A user entity that has the phone number.
+     *         {@code null} is returned if there is no user who has
+     *         the phone number.
+     */
+    public static User getByPhoneNumber(final String phoneNumber)
+    {
+        return get(new SearchCondition() {
+            @Override
+            public boolean check(UserEntity ue)
+            {
+                // Get the user's "phone_number" claim.
+                String ph = (String)ue.getClaim("phone_number", null);
+
+                // Check if the user's phone number is the target one.
+                return ph != null && ph.equals(phoneNumber);
+            }
+        });
     }
 }

--- a/src/main/java/com/authlete/jaxrs/server/db/UserDao.java
+++ b/src/main/java/com/authlete/jaxrs/server/db/UserDao.java
@@ -20,6 +20,10 @@ package com.authlete.jaxrs.server.db;
 import com.authlete.common.dto.Address;
 import com.authlete.common.types.User;
 
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.Date;
+
 
 /**
  * Operations to access the user database.
@@ -32,8 +36,12 @@ public class UserDao
      * Dummy user database.
      */
     private static final UserEntity[] sUserDB = {
-            new UserEntity("1001", "john", "john", "John Smith", "john@example.com",
-                    new Address().setCountry("USA"), "+1 (425) 555-1212", "675325"),
+            new UserEntity("1001", "john", "john", "John Flibble Smith", "john@example.com",
+                    new Address().setCountry("USA Flibble"), "+1 (425) 555-1212", "675325",
+                    "John", "Smith", "Doe", "Johnny",
+                    "https://example.com/john/profile", "https://example.com/john/me.jpg",
+                    "https://example.com/john/", "male", "Europe/London",
+                    "en-US", "john", "0000-03-22", Date.from(LocalDate.parse("2020-01-01").atStartOfDay().toInstant(ZoneOffset.UTC))),
             new UserEntity("1002", "jane", "jane", "Jane Smith", "jane@example.com",
                     new Address().setCountry("Chile"), "+56 (2) 687 2400", "264209"),
             new UserEntity("1003", "max", "max", "Max Meier", "max@example.com",

--- a/src/main/java/com/authlete/jaxrs/server/db/UserEntity.java
+++ b/src/main/java/com/authlete/jaxrs/server/db/UserEntity.java
@@ -21,6 +21,8 @@ import com.authlete.common.dto.Address;
 import com.authlete.common.types.StandardClaims;
 import com.authlete.common.types.User;
 
+import java.util.Date;
+
 
 /**
  * Dummy user entity that represents a user record.
@@ -76,6 +78,22 @@ public class UserEntity implements User
      */
     private String code;
 
+    // Below are standard claims as defined in https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
+    private boolean phoneNumberVerified;
+    private boolean emailVerified;
+    private String givenName;
+    private String familyName;
+    private String middleName;
+    private String nickName;
+    private String profile;
+    private String picture;
+    private String website;
+    private String gender;
+    private String zoneinfo;
+    private String locale;
+    private String preferredUsername;
+    private String birthdate;
+    private Date updatedAt;
 
     /**
      * Constructor with initial values.
@@ -92,6 +110,37 @@ public class UserEntity implements User
         this.address     = address;
         this.phoneNumber = phoneNumber;
         this.code        = code;
+    }
+
+    public UserEntity(
+            String subject, String loginId, String password, String name,
+            String email, Address address, String phoneNumber, String code,
+            String givenName, String familyName, String middleName,
+            String nickName, String profile, String picture, String website,
+            String gender, String zoneinfo, String locale,
+            String preferredUsername, String birthdate, Date updatedAt)
+    {
+        this.subject     = subject;
+        this.loginId     = loginId;
+        this.password    = password;
+        this.name        = name;
+        this.email       = email;
+        this.address     = address;
+        this.phoneNumber = phoneNumber;
+        this.code        = code;
+        this.givenName   = givenName;
+        this.familyName  = familyName;
+        this.middleName  = middleName;
+        this.nickName    = nickName;
+        this.profile     = profile;
+        this.picture     = picture;
+        this.website     = website;
+        this.gender      = gender;
+        this.zoneinfo    = zoneinfo;
+        this.locale      = locale;
+        this.preferredUsername = preferredUsername;
+        this.birthdate   = birthdate;
+        this.updatedAt   = updatedAt;
     }
 
 
@@ -156,6 +205,51 @@ public class UserEntity implements User
                 // "phone_number" claim. This claim can be requested by including "phone"
                 // in "scope" parameter of an authorization request.
                 return phoneNumber;
+
+            case StandardClaims.PHONE_NUMBER_VERIFIED:
+                return phoneNumberVerified;
+
+            case StandardClaims.EMAIL_VERIFIED:
+                return emailVerified;
+
+            case StandardClaims.BIRTHDATE:
+                return birthdate;
+
+            case StandardClaims.GIVEN_NAME:
+                return givenName;
+
+            case StandardClaims.FAMILY_NAME:
+                return familyName;
+
+            case StandardClaims.MIDDLE_NAME:
+                return middleName;
+
+            case StandardClaims.NICKNAME:
+                return nickName;
+
+            case StandardClaims.PROFILE:
+                return profile;
+
+            case StandardClaims.PICTURE:
+                return picture;
+
+            case StandardClaims.WEBSITE:
+                return website;
+
+            case StandardClaims.GENDER:
+                return gender;
+
+            case StandardClaims.ZONEINFO:
+                return zoneinfo;
+
+            case StandardClaims.LOCALE:
+                return locale;
+
+            case StandardClaims.UPDATED_AT:
+                return updatedAt.getTime() / 1000l;
+
+            case StandardClaims.PREFERRED_USERNAME:
+                return preferredUsername;
 
             default:
                 // Unsupported claim.

--- a/src/main/java/com/authlete/jaxrs/server/db/UserEntity.java
+++ b/src/main/java/com/authlete/jaxrs/server/db/UserEntity.java
@@ -36,6 +36,18 @@ public class UserEntity implements User
 
 
     /**
+     * The login ID.
+     */
+    private String loginId;
+
+
+    /**
+     * The login password.
+     */
+    private String password;
+
+
+    /**
      * The name of the user.
      */
     private String name;
@@ -60,17 +72,50 @@ public class UserEntity implements User
 
 
     /**
+     * The code of the user.
+     */
+    private String code;
+
+
+    /**
      * Constructor with initial values.
      */
     public UserEntity(
-            String subject, String name,
-            String email, Address address, String phoneNumber)
+            String subject, String loginId, String password, String name,
+            String email, Address address, String phoneNumber, String code)
     {
         this.subject     = subject;
+        this.loginId     = loginId;
+        this.password    = password;
         this.name        = name;
         this.email       = email;
         this.address     = address;
         this.phoneNumber = phoneNumber;
+        this.code        = code;
+    }
+
+
+    /**
+     * Get the login ID.
+     *
+     * @return
+     *         The login ID.
+     */
+    public String getLoginId()
+    {
+        return loginId;
+    }
+
+
+    /**
+     * Get the login password.
+     *
+     * @return
+     *         The login password.
+     */
+    public String getPassword()
+    {
+        return password;
     }
 
 
@@ -108,7 +153,7 @@ public class UserEntity implements User
                 return address;
 
             case StandardClaims.PHONE_NUMBER:
-                // "phone_number" claim. This claim can be requested by included "phone"
+                // "phone_number" claim. This claim can be requested by including "phone"
                 // in "scope" parameter of an authorization request.
                 return phoneNumber;
 
@@ -122,6 +167,20 @@ public class UserEntity implements User
     @Override
     public Object getAttribute(String attributeName)
     {
-        return null;
+        if (attributeName == null)
+        {
+            return null;
+        }
+
+        switch (attributeName)
+        {
+            case "code":
+                // The code of the user.
+                return code;
+
+            default:
+                // Unsupported attribute.
+                return null;
+        }
     }
 }


### PR DESCRIPTION
The main reason for doing this is so that the new java conformance tests for the userinfo endpoint pass without warnings.
